### PR TITLE
Implement Debug, Clone and Copy traits

### DIFF
--- a/src/splitmix.rs
+++ b/src/splitmix.rs
@@ -1,6 +1,7 @@
 use std::io;
 use {Rng, SeedableRng, Rand};
 
+#[derive(Debug, Clone, Copy)]
 pub struct SplitMix64Rng {
   state: u64
 }

--- a/src/xoroshiro.rs
+++ b/src/xoroshiro.rs
@@ -1,6 +1,7 @@
 use std::io;
 use {Rng, SeedableRng, Rand};
 
+#[derive(Debug, Clone, Copy)]
 pub struct Xoroshiro128Rng {
   state: [u64; 2]
 }

--- a/src/xorshift.rs
+++ b/src/xorshift.rs
@@ -3,6 +3,7 @@ use {Rng, SeedableRng, Rand};
 
 const ZERO_SEED: [u64; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
+#[derive(Debug, Clone, Copy)]
 pub struct XorShift1024Rng {
   state: [u64; 16],
   pointer: usize


### PR DESCRIPTION
When use those RNG with `local_thread!` and `std::cell::Cell`, they need implement `Copy` trait at least.